### PR TITLE
Build Linux packages using Docker

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,6 +39,9 @@ package-all:
 	$(MAKE) deps
 	./pkg/build.sh $(VERSION) -all
 
+docker-build:
+	./pkg/docker-build.sh $(VERSION)
+
 go-install:
 	go install -ldflags "-w -s $(LDFLAGS)" ./cmd/wavefront-proxy
 

--- a/README.md
+++ b/README.md
@@ -10,3 +10,25 @@ $ go get -d github.com/wavefronthq/go-proxy
 $ cd $GOPATH/src/wavefronthq/go-proxy
 $ make
 ```
+
+## To build packages
+
+#### Linux packages (.deb, .rpm)
+
+##### You have a [Docker environment](https://docs.docker.com/).
+
+```
+$ make docker-build 
+```
+
+##### You have a Linux installation.
+
+```
+$ make package
+```
+
+#### All packages (Linux, Windows, Darwin)
+
+```
+$ make package-all
+```

--- a/README.md
+++ b/README.md
@@ -1,2 +1,12 @@
 # go-proxy
 Go Proxy for Wavefront
+
+## To start developing
+
+##### You have a working [Go environment](https://golang.org/doc/install).
+
+```
+$ go get -d github.com/wavefronthq/go-proxy
+$ cd $GOPATH/src/wavefronthq/go-proxy
+$ make
+```

--- a/pkg/Dockerfile-build
+++ b/pkg/Dockerfile-build
@@ -1,0 +1,12 @@
+# Dockerfile for building the wavefront go-proxy .deb and .rpm packages.
+FROM golang:1.9.2
+RUN apt-get -qq update
+RUN apt-get -qq install -y --no-install-recommends ruby ruby-dev rubygems build-essential rpm
+RUN gem install fpm --version 1.9.3
+
+ENV USER wavefronthq
+ENV REPO go-proxy
+
+RUN mkdir -p $GOPATH/src/github.com/$USER
+COPY . $GOPATH/src/github.com/$USER/$REPO
+RUN cd $GOPATH/src/github.com/$USER/$REPO && make package

--- a/pkg/build.sh
+++ b/pkg/build.sh
@@ -95,6 +95,7 @@ do
         --license "Apache 2.0" \
         --maintainer "Wavefront <support@wavefront.com>" \
         --name wavefront-proxy \
+        --version $VERSION \
         --package $OUT_DIR/linux/amd64 \
         -s dir \
         -t ${pkg} \

--- a/pkg/docker-build.sh
+++ b/pkg/docker-build.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+
+which docker
+if [[ $? -ne 0 ]] ; then
+    echo "Error: docker not found."
+    exit 1
+fi
+
+CURR_DIR=$(pwd)
+#VERSION=$1-`date +%s`
+VERSION=$1
+
+rm -rf ${CURR_DIR}/build
+mkdir -p ${CURR_DIR}/build
+
+PREFIX="goproxy-build"
+
+echo "Building go-proxy docker image..."
+docker build -t ${PREFIX}:$VERSION -f ${CURR_DIR}/pkg/Dockerfile-build .
+
+echo "Copying files from docker image..."
+CONTAINER_ID=`docker run -d -t ${PREFIX}:${VERSION}`
+docker cp ${CONTAINER_ID}:/go/src/github.com/wavefronthq/go-proxy/build/linux  ${CURR_DIR}/build/
+
+echo "Cleaning up build container..."
+docker stop ${CONTAINER_ID}
+docker container rm ${CONTAINER_ID}

--- a/pkg/docker-build.sh
+++ b/pkg/docker-build.sh
@@ -7,7 +7,6 @@ if [[ $? -ne 0 ]] ; then
 fi
 
 CURR_DIR=$(pwd)
-#VERSION=$1-`date +%s`
 VERSION=$1
 
 rm -rf ${CURR_DIR}/build
@@ -25,3 +24,5 @@ docker cp ${CONTAINER_ID}:/go/src/github.com/wavefronthq/go-proxy/build/linux  $
 echo "Cleaning up build container..."
 docker stop ${CONTAINER_ID}
 docker container rm ${CONTAINER_ID}
+
+echo "Done. Packages available under: ${CURR_DIR}/build"

--- a/points/forwarder.go
+++ b/points/forwarder.go
@@ -99,7 +99,6 @@ func (f *DefaultPointForwarder) addPoint(point string) {
 func (f *DefaultPointForwarder) checkOverflow() {
 	ptsLength := len(f.points)
 	if ptsLength > f.maxBufferSize {
-		log.Printf("Too many pending points: %d. Draining to queue.", ptsLength)
 		f.drainToQueue()
 	}
 }

--- a/points/queue.go
+++ b/points/queue.go
@@ -1,7 +1,5 @@
 package points
 
-import "log"
-
 type PointQueue interface {
 	queuePoints(points []string)
 }
@@ -12,5 +10,4 @@ var bufferQueue = DefaultPointQueue{}
 
 func (DefaultPointQueue) queuePoints(points []string) {
 	//TODO: dropping on the floor for now, enhance to buffer to disk and process the buffer queues
-	log.Printf("Dropping points of length: %d", len(points))
 }


### PR DESCRIPTION
Added support to build the go-proxy Linux packages using a docker image. This allows to easily build Linux packages (.deb, .rpm) on Mac or Windows.