### PR TITLE
MONIT-7982 & MONIT-7879

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 PREFIX := /usr/local
-VERSION := 0.2
+VERSION := 0.30
 TAG := $(shell git describe --exact-match --tags 2>/dev/null)
 COMMIT := $(shell git rev-parse --short HEAD)
 BRANCH := $(shell git rev-parse --abbrev-ref HEAD)

--- a/points/parser/element.go
+++ b/points/parser/element.go
@@ -163,13 +163,15 @@ func (ep *TagParser) parse(p *PointParser, pt *common.Point) error {
 }
 
 func (ep *WhiteSpaceParser) parse(p *PointParser, pt *common.Point) error {
-	tok, lit := p.scan()
-	if tok != WS {
-		if tok == EOF {
-			return ErrEOF
-		}
-		return fmt.Errorf("found %q, expected whitespace", lit)
+	tok := WS
+	for tok != EOF && tok == WS {
+		tok, _ = p.scan()
 	}
+
+	if tok == EOF {
+		return ErrEOF
+	}
+	p.unscan()
 	return nil
 }
 

--- a/points/parser/graphite_test.go
+++ b/points/parser/graphite_test.go
@@ -23,6 +23,9 @@ var validPoints = [...]string{
 	"foo.metric 1.5 host=foo-linux",
 	"foo.metric 1.5 1505454047 host=foo-linux",
 
+	// verify extra space is allowed
+	"foo.metric 1.5    1505454047    host=foo-linux",
+
 	// tags
 	"foo.metric 1.5 source=foo-linux env=dev",
 	"foo.metric 1.5 source=foo-linux env=dev region=us-west2",

--- a/points/parser/opentsdb_test.go
+++ b/points/parser/opentsdb_test.go
@@ -19,6 +19,9 @@ var validTSDBPoints = [...]string{
 	// host
 	"put foo.metric 1505454047 1.5 host=foo-linux",
 
+	// verify extra space is allowed
+	"put foo.metric    1505454047 1.5 host=foo-linux",
+
 	// tags
 	"put mac.disk.total 1504118031 4.9895440384E11 source=Vikrams-MacBook-Pro.local path=/ os=Mac device=disk1 fstype=hfs",
 


### PR DESCRIPTION
MONIT-7942: Introduce versioning to the go proxy (go-proxy `build.version` metric was not being sent to Wavefront)

MONIT-7982: Trim white spaces in the tsdb and still accept in in go proxy (Proxy allowed only a single whitespace character between point elements. Changed to be less strict/consume all whitespace characters between elements)

