### PR TITLE
accept values with a negative exponent

### DIFF
--- a/points/parser/element.go
+++ b/points/parser/element.go
@@ -57,7 +57,8 @@ func (ep *ValueParser) parse(p *PointParser, pt *common.Point) error {
 		tok, lit = p.scan()
 	}
 
-	for tok != EOF && (tok == LETTER || tok == NUMBER || tok == DOT) {
+	for tok != EOF && (tok == LETTER || tok == NUMBER || tok == DOT ||
+		tok == MINUS_SIGN) {
 		p.writeBuf.WriteString(lit)
 		tok, lit = p.scan()
 	}

--- a/points/parser/graphite_test.go
+++ b/points/parser/graphite_test.go
@@ -19,6 +19,14 @@ var validPoints = [...]string{
 	"foo.metric 1 source=foo-linux",
 	"foo.metric 1 1505454047 source=foo-linux",
 
+	// exponential values
+	"foo.metric 1e05 source=foo-linux",
+	"foo.metric 1e05 1505454047 source=foo-linux",
+	"foo.metric 1e-05 source=foo-linux",
+	"foo.metric 1e-05 source=foo-linux",
+	"foo.metric 1e5 1505454047 source=foo-linux",
+	"foo.metric 1e-5 1505454047 source=foo-linux",
+
 	// host
 	"foo.metric 1.5 host=foo-linux",
 	"foo.metric 1.5 1505454047 host=foo-linux",
@@ -47,6 +55,7 @@ var invalidPoints = [...]string{
 	"foo.metric 1.5.0 source=foo-linux",
 	"system.cpu.loadavg source=test.wavefront.com",
 	"te\"st.metric 1 1505454047 source=test",
+	"foo.metric 1e05e source=foo-linux",
 }
 
 func TestValidPoints(t *testing.T) {


### PR DESCRIPTION
Values with negative exponents were being rejected by the proxy.

```
2018/11/15 10:11:26 2878-handler: blocked point: "mqtt-bridge.cache.misses.m1_rate" 1.383502708828376E-4 1542276683 source="dropwizard-metrics"
2018/11/15 10:11:26 Error decoding point invalid metric value 1.383502708828376E
```

This patch allows values of the form `1.0E-05` to pass through the proxy.